### PR TITLE
relax bytestring dep for ghc 7.5

### DIFF
--- a/charset.cabal
+++ b/charset.cabal
@@ -30,7 +30,7 @@ library
   build-depends:
     base                 >= 4       && < 5,
     array                >= 0.2     && < 0.5,
-    bytestring           == 0.9.*,
+    bytestring           >= 0.9     && < 0.11,
     containers           >= 0.2     && < 0.6,
     semigroups           >= 0.8.3.1 && < 0.9,
     unordered-containers >= 0.1.4.6 && < 0.3


### PR DESCRIPTION
Compiled with 7.5.20120621 and ghc 7.4.2.
