### PR TITLE
charset.cabal: drop not-used-anymore OldTypeable flag

### DIFF
--- a/charset.cabal
+++ b/charset.cabal
@@ -19,10 +19,6 @@ source-repository head
   type: git
   location: git://github.com/ekmett/charset.git
 
-flag OldTypeable
-  manual: False
-  default: False
-
 library
   extensions: CPP
   other-extensions: MagicHash, BangPatterns


### PR DESCRIPTION
Signed-off-by: Sergei Trofimovich slyfox@gentoo.org
