### PR TITLE
Conditionally derive instance Typeable Charset.

### DIFF
--- a/src/Data/CharSet.hs
+++ b/src/Data/CharSet.hs
@@ -3,6 +3,10 @@
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
 #endif
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 708
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE StandaloneDeriving #-}
+#endif
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.CharSet
@@ -275,8 +279,12 @@ numChars :: Int
 numChars = oh - ol + 1
 {-# INLINE numChars #-}
 
+#if defined (__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 708
+deriving instance Typeable CharSet
+#else
 instance Typeable CharSet where
   typeOf _ = mkTyConApp charSetTyCon []
+#endif
 
 charSetTyCon :: TyCon
 #if MIN_VERSION_base(4,4,0)


### PR DESCRIPTION
This makes `charset` compile on GHC 7.8.

```
(22:37) < startling> k. :)
(22:37) < startling> I'm trying to use parsers on 7.8, charset does not compile
                     because of the new Typeable
(22:37) < startling> oh, to clarify: it has a handwritten Typeable instance
(22:39) < edwardk> oh then just have it conditionally build its typeable
                   instance by hand
(22:40) < c_wraith> startling: there were a bunch of cases where the old
                    Typeable couldn't be derived, which is one of many ways the
                    new Typeable is much better
(22:40) < startling> when is a hand-written Typeable instance better?
(22:40) < startling> c_wraith: ah.
(22:41) < c_wraith> It's never better.  But sometimes it was your only option.
                    :)
```
