### PR TITLE
Allow containers 0.7, as released with GHC 8.6.

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+Next
+----
+* Updated dependency bounds to support GHC 8.6.
+
 0.3.7.1
 -------
 * Minor haddock fixup.

--- a/charset.cabal
+++ b/charset.cabal
@@ -27,7 +27,7 @@ library
     base                 >= 4       && < 5,
     array                >= 0.2     && < 0.6,
     bytestring           >= 0.9     && < 0.11,
-    containers           >= 0.2     && < 0.6,
+    containers           >= 0.2     && < 0.7,
     semigroups           >= 0.8.3.1 && < 1,
     unordered-containers >= 0.1.4.6 && < 0.3
 


### PR DESCRIPTION
After this is merged, a release or revision would be very handy, please.