### PR TITLE
Depend on semigroups only on GHC < 8.0

### DIFF
--- a/charset.cabal
+++ b/charset.cabal
@@ -42,8 +42,9 @@ library
     array                >= 0.2     && < 0.6,
     bytestring           >= 0.9     && < 0.11,
     containers           >= 0.2     && < 0.7,
-    semigroups           >= 0.8.3.1 && < 1,
     unordered-containers >= 0.1.4.6 && < 0.3
+  if impl(ghc < 8.0)
+    build-depends: semigroups >= 0.8.3.1 && < 1
 
   exposed-modules:
     Data.CharSet


### PR DESCRIPTION
They are not needed on newer GHC.